### PR TITLE
 Updated sphinx requirement from 4.4.0 to 5.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==4.4
+sphinx==5.3.0
 sphinx_rtd_theme
 sphinx_rtd_dark_mode
 docutils<0.18


### PR DESCRIPTION
Fixes #6 . 

This might only be a problem on Windows? I was only able to test on Python 3.10, Windows 10.  

Without this, `make html` returns: 
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.