### PR TITLE
Improve instructions and guidance around signing

### DIFF
--- a/docs/intro/apple-silicon-support.md
+++ b/docs/intro/apple-silicon-support.md
@@ -9,6 +9,8 @@ Not all Adobe products have native Apple Silicon versions yet, but in those that
 
 To learn more about Universal binaries, please visit [https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary)
 
+Loading plugins on macOS 15+ for debugging also requires an additional signing step. See [here](debugging-plug-ins.md#loading-unsigned-plugins) for details.
+
 ---
 
 ## How to add Universal Binary Support for your Plugins

--- a/docs/intro/apple-silicon-support.md
+++ b/docs/intro/apple-silicon-support.md
@@ -5,7 +5,7 @@ Adobe now supports Apple Silicon effect plugins in some products running nativel
 Not all Adobe products have native Apple Silicon versions yet, but in those that do, only effect plugins with Apple Silicon implementations will be available. We recommend adding the Apple Silicon target soon in anticipation of rapid adoption of these new M1 machines.
 
 !!! note
-    In order to build a Mac Universal binary, you will need Xcode 12.2 or greater. Adobe is currently using Xcode 12.4.
+    In order to build a Mac Universal binary, you will need Xcode 12.2 or greater.
 
 To learn more about Universal binaries, please visit [https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary)
 

--- a/docs/intro/apple-silicon-support.md
+++ b/docs/intro/apple-silicon-support.md
@@ -9,7 +9,7 @@ Not all Adobe products have native Apple Silicon versions yet, but in those that
 
 To learn more about Universal binaries, please visit [https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary)
 
-Loading plugins on macOS 15+ for debugging also requires an additional signing step. See [here](debugging-plug-ins.md#loading-unsigned-plugins) for details.
+Loading plugins on macOS 15+ for debugging also requires an additional signing step. See [here](debugging-plug-ins.md#signing-requirments-and-loading-unsigned-plug-ins) for details.
 
 ---
 

--- a/docs/intro/debugging-plug-ins.md
+++ b/docs/intro/debugging-plug-ins.md
@@ -19,6 +19,14 @@ Once you've got the plug-in building directly into the plug-ins folder as explai
 3. Under Run, in the Info tab, for Executable, choose the host application the plug-ins will be running in (this may be After Effects or Premiere Pro)
 4. From there you can either hit the Play button to build and run the current scheme, or you can launch the application and later at any point choose Debug > Attach to Process.
 
+#### Loading unsigned plugins
+
+macOS versions 15+ prevent the loading of unsigned plugins. You can avoid this difficulty by adding ad-hoc signing as a custom build step.
+
+`codesign --force --deep --sign - /path/to/plugin.dylib`
+
+Note: Yes, that trailing '-' after '--sign' is important.
+
 ---
 
 ## Deleting Preferences

--- a/docs/intro/debugging-plug-ins.md
+++ b/docs/intro/debugging-plug-ins.md
@@ -19,13 +19,15 @@ Once you've got the plug-in building directly into the plug-ins folder as explai
 3. Under Run, in the Info tab, for Executable, choose the host application the plug-ins will be running in (this may be After Effects or Premiere Pro)
 4. From there you can either hit the Play button to build and run the current scheme, or you can launch the application and later at any point choose Debug > Attach to Process.
 
-#### Loading unsigned plugins
+#### Signing requirments and loading unsigned plug-ins
 
-macOS versions 15+ prevent the loading of unsigned plugins. You can avoid this difficulty by adding ad-hoc signing as a custom build step.
+macOS versions 15+ prevent the loading of unsigned plugins. During development, you can avoid this difficulty by adding ad-hoc signing as a custom build step.
 
 `codesign --force --deep --sign - /path/to/plugin.dylib`
 
 Note: Yes, that trailing '-' after '--sign' is important.
+
+When you are ready to release, ensure that you do _not_ make changes to the plug-in package after signing, as this will invalidate said signing and prevent the plug-in from loading.
 
 ---
 

--- a/docs/intro/debugging-plug-ins.md
+++ b/docs/intro/debugging-plug-ins.md
@@ -4,7 +4,7 @@ The best way to learn the interaction(s) between After Effects and plug-ins is r
 
 Once you've got the plug-in building directly into the plug-ins folder as explained above, here's how to specify After Effects as the application to run during debug sessions:
 
-### Windows:
+### Windows
 
 1. In the Visual Studio solution, in the Solution Explorer panel, choose the project you want to debug
 2. Right-click it and choose Set as StartUp Project
@@ -12,7 +12,7 @@ Once you've got the plug-in building directly into the plug-ins folder as explai
 4. In Configuration Properties > Debugging > Command, provide the path to the executable file of the host application the plug-ins will be running in (this may be After Effects or Premiere Pro)
 5. From there you can either hit the Play button, or you can launch the application and later at any point choose Debug > Attach to Process...
 
-### macOS:
+### macOS
 
 1. In Xcode, in the Project Navigator, choose the xcodeproj you want to debug
 2. Choose Product > Scheme > Edit Scheme...


### PR DESCRIPTION
This PR adds updated guidance on signing plug-ins on macOS, in line with changes introduced in 25.2, along with some small cleanup.

In all Adobe video apps, version 25.2 introduced a requirement on macOS 15+ that all plug-ins must be signed to be loaded. This was added to the Premiere plug-in docs as well: https://github.com/docsforadobe/premiere-plugin-guide/commit/4781161cca926f3e14532e1ca7e7311b92779b46.